### PR TITLE
Should use mocking framework instead of creating your own stubs

### DIFF
--- a/project/tests/test_project.py
+++ b/project/tests/test_project.py
@@ -1,17 +1,7 @@
 import unittest
-
+from mockito import *
 from lib import Options
 from lib import Project
-
-class MockProcess:
-
-  def __init__(self):
-    self.commands = []
-
-  def execute(self, command):
-    self.commands.append(command)
-
-
 
 class TestProject(unittest.TestCase):
   def _default_options(self):
@@ -22,11 +12,9 @@ class TestProject(unittest.TestCase):
   
   def setUp(self):
     self.machine = Project(self._default_options())
-
-    self.mock_process = MockProcess()
+    self.mock_process = mock()
     self.machine.process = self.mock_process
   
   def test_machine_should_get_date(self):
     self.machine.date()
-    
-    self.assertTrue("date" in self.mock_process.commands)
+    verify(self.mock_process).execute(any())


### PR DESCRIPTION
Changed the project test to use mockito as mocking framework instead of creating your own stub. In the long run and in bigger projects it's much more efficient to use real mocking frameworks.

Mockito can be installed using easy_install (easy_install mockito) or pip (pip install mockito)
